### PR TITLE
remove *surfaceForm* in _convert_number function

### DIFF
--- a/spotlight/__init__.py
+++ b/spotlight/__init__.py
@@ -108,7 +108,10 @@ def _dict_cleanup(dic, dict_type=dict):
             except KeyError:
                 clean[key] = _dict_cleanup(value, dict_type)
         except AttributeError:
-            clean[key] = _convert_number(value)
+            if key == 'surfaceForm':
+                clean[key] = value
+            else:
+                clean[key] = _convert_number(value)
     return clean
 
 


### PR DESCRIPTION
In case the key *sufaceForm* may be some numbers , such as *02*,  but in the code , it will be converted into *2*,  it will cause errors in *offset*